### PR TITLE
Länge der Ausgabedateinamen begrenzt

### DIFF
--- a/preprocessing/sexy_magic.ipynb
+++ b/preprocessing/sexy_magic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -15,8 +15,7 @@
       "['Jg. 63, 1904']\n",
       "C:\\Users\\Philip\\Documents\\Python35-32_Scripts\\TopicModeling/raw\\vls-suubdfggb-1904-341879\\export_mets.xml : done\n",
       "doing:  C:\\Users\\Philip\\Documents\\Python35-32_Scripts\\TopicModeling/raw\\vls-suubdfggb-1905-341881\\export_mets.xml\n",
-      "['Jg. 64, 1905']\n",
-      "C:\\Users\\Philip\\Documents\\Python35-32_Scripts\\TopicModeling/raw\\vls-suubdfggb-1905-341881\\export_mets.xml : done\n"
+      "['Jg. 64, 1905']\n"
      ]
     }
    ],
@@ -84,7 +83,7 @@
     "    dir1 = wo die Datein hinsollen\n",
     "    dir2 = wo die Datein herkommen\n",
     "    '''\n",
-    "    dir1 = outdir + label[:12] + '\\\\' + re.sub('[^a-zA-Z0-9]', '_' , re.sub(' ', '' , label[12:])) + '.txt'\n",
+    "    dir1 = outdir + label[:12] + '\\\\' + re.sub('[^a-zA-Z0-9]', '_' , re.sub(' ', '' , label[12:100])) + '.txt'\n",
     "\n",
     "    \n",
     "    dir2 = directory[:-15] + '\\\\fulltext\\\\'\n",

--- a/preprocessing/sexy_magic.py
+++ b/preprocessing/sexy_magic.py
@@ -66,7 +66,7 @@ def createFile(label, fileList, directory, outdir):
     dir1 = wo die Datein hinsollen
     dir2 = wo die Datein herkommen
     '''
-    dir1 = outdir + label[:12] + '\\' + re.sub('[^a-zA-Z0-9]', '_' , re.sub(' ', '' , label[12:])) + '.txt'
+    dir1 = outdir + label[:12] + '\\' + re.sub('[^a-zA-Z0-9]', '_' , re.sub(' ', '' , label[12:100])) + '.txt'
 
     
     dir2 = directory[:-15] + '\\fulltext\\'


### PR DESCRIPTION
Ausgabedateien sollten keinen Fehler mehr versursachen weil der Dateiname zu Lang ist.
